### PR TITLE
Return proper error when checking for ECR image deletion failure

### DIFF
--- a/pkg/prune/prune.go
+++ b/pkg/prune/prune.go
@@ -297,13 +297,9 @@ func (gc *Client) PruneRepo(ctx context.Context, name string, until time.Time, e
 	if err != nil {
 		return nil, err
 	}
-	if batchDeleteImageErr != nil {
-		span.Finish(tracer.WithError(err))
-		return pruned, fmt.Errorf("error deleting images: %w", err)
-	}
 	pruned = deleted
 	if batchDeleteImageErr != nil {
-		span.Finish(tracer.WithError(err))
+		span.Finish(tracer.WithError(batchDeleteImageErr))
 		return pruned, fmt.Errorf("error deleting images: %w", err)
 	}
 	return pruned, nil


### PR DESCRIPTION
The code was previously checking batchDeleteImageError, but was returning the error from converting the ECR images to imageref strings. Thermite jobs are failing in prod and returning this incorrect error, meaning we don't have insight into what is causing it, which this fixes.