### PR TITLE
Chunk ECR BatchDeleteImage IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.vscode


### PR DESCRIPTION
The misreported error deleting images turned out to be a limit I hadn't noticed of 100 image IDs per BatchDeleteImage request, which this PR fixes.