### PR TITLE
Go 1.18: Remove 'replace' directive from go.mod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.16
-    working_directory: /go/src/github.com/dollarshaveclub/thermite
+      - image: cimg/go:1.18
     steps:
       - checkout
       - run: go build -v ./...
@@ -12,8 +11,7 @@ jobs:
       branches:
         ignore: gh-pages
     docker:
-      - image: circleci/golang:1.16
-    working_directory: /go/src/github.com/dollarshaveclub/thermite
+      - image: cimg/go:1.18
     steps:
       - checkout
       - run: go fmt ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.17-alpine3.14 AS build
+FROM golang:1.18-alpine3.15 AS build
 COPY . /go/src/github.com/dollarshaveclub/thermite/
 WORKDIR /go/src/github.com/dollarshaveclub/thermite/
-RUN CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/thermite
-FROM alpine:3.14
+RUN apk update && apk add git && CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/thermite
+FROM alpine:3.15
 COPY --from=build /bin/thermite /bin/thermite
 ENTRYPOINT ["/bin/thermite"]

--- a/charts/thermite/Chart.yaml
+++ b/charts/thermite/Chart.yaml
@@ -5,4 +5,4 @@ description: Removes old and undeployed Amazon Elastic Container Registry images
 sources:
   - https://github.com/dollarshaveclub/thermite
 type: application
-appVersion: 0.0.31
+appVersion: 0.0.32

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,7 +130,7 @@ func run(logger *log.Logger) (pruned []string, err error) {
 }
 
 var RootCmd = &cobra.Command{
-	Version: "0.0.31",
+	Version: "0.0.32",
 	Use:     "thermite",
 	Short:   "Remove old and undeployed Amazon Elastic Container Registry images",
 	Long: `Thermite removes old Amazon Elastic Container Registry images that are not

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/dollarshaveclub/thermite
 
-go 1.17
-
-replace github.com/go-logr/logr => github.com/go-logr/logr v0.4.0 // indirect
+go 1.18
 
 require (
 	cloud.google.com/go v0.94.0 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -91,7 +91,7 @@ github.com/davecgh/go-spew/spew
 # github.com/evanphx/json-patch v4.11.0+incompatible
 ## explicit
 github.com/evanphx/json-patch
-# github.com/go-logr/logr v0.4.0 => github.com/go-logr/logr v0.4.0
+# github.com/go-logr/logr v0.4.0
 ## explicit; go 1.14
 github.com/go-logr/logr
 # github.com/gogo/protobuf v1.3.2
@@ -620,4 +620,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/go-logr/logr => github.com/go-logr/logr v0.4.0


### PR DESCRIPTION
It's no longer supported for installing using `go install`